### PR TITLE
Set idle timer disabled when waiting for a live game to start

### DIFF
--- a/Surround/Components/ChallengeCell.swift
+++ b/Surround/Components/ChallengeCell.swift
@@ -442,63 +442,59 @@ struct ChallengeCell: View {
                     Spacer()
                 }
             }
-            if let game = challenge.game {
-                VStack(alignment: .leading, spacing: 3) {
-                    Label{
-                        HStack {
-                            Text("\(game.width)×\(game.height) \(game.ranked ? "Ranked" : "Unranked")")
-                                .leadingAlignedInScrollView()
-                                .minimumScaleFactor(0.7)
-                                .lineLimit(1)
+            let game = challenge.game
+            VStack(alignment: .leading, spacing: 3) {
+                Label{
+                    HStack {
+                        Text("\(game.width)×\(game.height) \(game.ranked ? "Ranked" : "Unranked")")
+                            .leadingAlignedInScrollView()
+                            .minimumScaleFactor(0.7)
+                            .lineLimit(1)
+                        Spacer()
+                        Text("Handicap: ").bold()
+                            .offset(x: 8)
+                        Text(game.handicap == -1 ? "Auto" : "\(game.handicap)")
+                    }
+                } icon: {
+                    Image(systemName: "squareshape.split.3x3")
+                }
+                Label {
+                    HStack {
+                        (Text("Rules: ").bold() + Text(game.rules.fullName))
+                            .leadingAlignedInScrollView()
+                            .minimumScaleFactor(0.7)
+                            .lineLimit(1)
+                        if game.komi != nil && game.komi != game.rules.defaultKomi {
                             Spacer()
-                            Text("Handicap: ").bold()
+                            Text("Komi: ").bold()
                                 .offset(x: 8)
-                            Text(game.handicap == -1 ? "Auto" : "\(game.handicap)")
+                            Text(String(format: "%.1f", game.komi!))
                         }
-                    } icon: {
-                        Image(systemName: "squareshape.split.3x3")
                     }
-                    Label {
-                        HStack {
-                            (Text("Rules: ").bold() + Text(game.rules.fullName))
-                                .leadingAlignedInScrollView()
-                                .minimumScaleFactor(0.7)
-                                .lineLimit(1)
-                            if game.komi != nil && game.komi != game.rules.defaultKomi {
-                                Spacer()
-                                Text("Komi: ").bold()
-                                    .offset(x: 8)
-                                Text(String(format: "%.1f", game.komi!))
-                            }
+                } icon: {
+                    Image(systemName: "text.badge.checkmark")
+                }
+                let timeControl = game.timeControl
+                Label {
+                    VStack(alignment: .leading) {
+                        Text("\(timeControl.systemName): \(timeControl.shortDescription)")
+                            .leadingAlignedInScrollView()
+                        if (timeControl.pauseOnWeekends ?? false) && timeControl.speed == .correspondence {
+                            Text("Pause on weekend")
                         }
-                    } icon: {
-                        Image(systemName: "text.badge.checkmark")
                     }
-                    if let timeControl = game.timeControl {
-                        Label {
-                            VStack(alignment: .leading) {
-                                Text("\(timeControl.systemName): \(timeControl.shortDescription)")
-                                    .leadingAlignedInScrollView()
-                                if (timeControl.pauseOnWeekends ?? false) && timeControl.speed == .correspondence {
-                                    Text("Pause on weekend")
-                                }
-                            }
-                            
-                        } icon: {
-                            Image(systemName: "clock")
-                        }
-                    } else {
-                        Label("No time limits", systemImage: "clock")
-                    }
-                    Label("Analysis \(game.disableAnalysis ? "disabled" : "enabled")", systemImage: "arrow.triangle.branch")
-                    if let minRank = game.minRank, let maxRank = game.maxRank {
-                        if minRank > -1000 && maxRank < 1000 {
-                            Label("\(RankUtils.formattedRank(Double(minRank), longFormat: true)) - \(RankUtils.formattedRank(Double(maxRank), longFormat: true))", systemImage: "arrow.up.and.down.square")
-                        }
+                    
+                } icon: {
+                    Image(systemName: "clock")
+                }
+                Label("Analysis \(game.disableAnalysis ? "disabled" : "enabled")", systemImage: "arrow.triangle.branch")
+                if let minRank = game.minRank, let maxRank = game.maxRank {
+                    if minRank > -1000 && maxRank < 1000 {
+                        Label("\(RankUtils.formattedRank(Double(minRank), longFormat: true)) - \(RankUtils.formattedRank(Double(maxRank), longFormat: true))", systemImage: "arrow.up.and.down.square")
                     }
                 }
-                .font(.subheadline)
             }
+            .font(.subheadline)
         }
     }
 }

--- a/Surround/Components/PrivateMessageLog.swift
+++ b/Surround/Components/PrivateMessageLog.swift
@@ -27,24 +27,23 @@ struct PrivateMessageLine: View {
                 }
             }
             HStack {
-                if let fromUser = ogs.user?.id == message.from.id {
-                    if fromUser {
-                        Spacer()
+                let fromUser = ogs.user?.id == message.from.id
+                if fromUser {
+                    Spacer()
+                }
+                VStack(alignment: fromUser ? .trailing : .leading, spacing: 2) {
+                    if lastMessage == nil || message.content.dateString != lastMessage?.content.dateString || message.from.id != lastMessage?.from.id {
+                        Text(message.from.username).font(.caption2).bold()
+                        .foregroundColor(message.from.uiColor)
                     }
-                    VStack(alignment: fromUser ? .trailing : .leading, spacing: 2) {
-                        if lastMessage == nil || message.content.dateString != lastMessage?.content.dateString || message.from.id != lastMessage?.from.id {
-                            Text(message.from.username).font(.caption2).bold()
-                            .foregroundColor(message.from.uiColor)
-                        }
-                        Text(message.content.message).font(.callout)
-                    }
-                    .padding(.horizontal, 10)
-                    .padding(.vertical, 5)
-                    .background(Color(.systemGray4))
-                    .cornerRadius(10)
-                    if !fromUser {
-                        Spacer()
-                    }
+                    Text(message.content.message).font(.callout)
+                }
+                .padding(.horizontal, 10)
+                .padding(.vertical, 5)
+                .background(Color(.systemGray4))
+                .cornerRadius(10)
+                if !fromUser {
+                    Spacer()
                 }
             }.padding(.horizontal)
         }

--- a/Surround/Views/GameDetail/GameDetailView.swift
+++ b/Surround/Views/GameDetail/GameDetailView.swift
@@ -212,16 +212,10 @@ struct GameDetailView: View {
         .navigationBarBackButtonHidden(navigationBarHidden)
         .navigationBarTitleDisplayMode(.inline)
         .onAppear {
-            if currentGame.gameData?.timeControl.speed == .live || currentGame.gameData?.timeControl.speed == .blitz {
-                UIApplication.shared.isIdleTimerDisabled = true
-            }
             updateActiveGameList()
             DispatchQueue.main.async {
                 self.updateDetailOfCurrentGameIfNecessary()
             }
-        }
-        .onDisappear {
-            UIApplication.shared.isIdleTimerDisabled = false
         }
         .onChange(of: currentGame) { [currentGame] newGame in
             if newGame.ID != currentGame.ID {

--- a/Surround/Views/MainView.swift
+++ b/Surround/Views/MainView.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 import WidgetKit
+import Combine
 
 struct MainView: View {
     #if os(iOS)
@@ -177,6 +178,9 @@ struct MainView: View {
                 }
             }
         }
+        .onReceive(Publishers.CombineLatest(ogs.$liveGames, ogs.$waitingLiveGames), perform: { liveGames, waitingLiveGames in
+            UIApplication.shared.isIdleTimerDisabled = !liveGames.isEmpty || waitingLiveGames > 0
+        })
         .onOpenURL { url in
             navigateTo(appURL: url)
         }

--- a/Surround/Views/PrivateMessagesView.swift
+++ b/Surround/Views/PrivateMessagesView.swift
@@ -56,16 +56,15 @@ struct PrivateMessagesView: View {
                                     .frame(width: 48, height: 48)
                                     .background(Color.gray)
                             }
-                            if let hasUnread = userDefaults[.lastSeenPrivateMessageByOGSUserId]?[peer.id] ?? 0 < lastMessage.content.timestamp {
-                                VStack(alignment: .leading) {
-                                    Text(peer.username)
-                                        .foregroundColor(peer.uiColor)
-                                        .font(hasUnread ? Font.body.bold() : .body)
-                                    Text(lastMessage.content.message)
-                                        .font(hasUnread ? Font.subheadline.bold() : .subheadline)
-                                        .foregroundColor(Color(.secondaryLabel))
-                                        .lineLimit(1)
-                                }
+                            let hasUnread = userDefaults[.lastSeenPrivateMessageByOGSUserId]?[peer.id] ?? 0 < lastMessage.content.timestamp
+                            VStack(alignment: .leading) {
+                                Text(peer.username)
+                                    .foregroundColor(peer.uiColor)
+                                    .font(hasUnread ? Font.body.bold() : .body)
+                                Text(lastMessage.content.message)
+                                    .font(hasUnread ? Font.subheadline.bold() : .subheadline)
+                                    .foregroundColor(Color(.secondaryLabel))
+                                    .lineLimit(1)
                             }
                         }
                     }

--- a/SurroundWidgets/SurroundWidgets.swift
+++ b/SurroundWidgets/SurroundWidgets.swift
@@ -282,13 +282,11 @@ struct CorrespondenceGamesWidgetView : View {
             }
             HStack {
                 timer(game: game)
-                if let userId = userId {
-                    if let pauseReason = game.pauseControl?.pauseReason(playerId: userId) {
-                        Text(pauseReason)
-                            .font(Font.caption2.bold())
-                            .lineLimit(1)
-                            .minimumScaleFactor(0.7)
-                    }
+                if let pauseReason = game.pauseControl?.pauseReason(playerId: userId) {
+                    Text(pauseReason)
+                        .font(Font.caption2.bold())
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.7)
                 }
             }.frame(width: boardSize)
         }


### PR DESCRIPTION
Before this change the app would let the device go to sleep while waiting for a new game. Then when you unlock the screen, the app reconnects and your game request is gone and you have to request a new one. And the idle timer was only being disabled when you open the live game. Now the idle timer is disabled whenever you have a live game or an outbound live challenge.

I had to make other changes to get this to build with Xcode 14.3.1. There were places where `if let x = y` was being used where y wasn't an optional, and the newer Swift compiler doesn't allow that. Let me know if you want me to remove those changes from this PR or separate them into another PR.

I ran this in the simulator to confirm that the idle timer gets disabled when you request a game. But it'd be worth testing this on your phone before shipping it.