### PR TITLE
Hide pause reason from timer when game is finished, not paused

### DIFF
--- a/Surround/Components/GameCell.swift
+++ b/Surround/Components/GameCell.swift
@@ -48,7 +48,7 @@ struct PlayerInfoLine: View {
                             .font(.subheadline)
                     }
                     Spacer()
-                    InlineTimerView(timeControl: game.gameData?.timeControl, clock: game.clock, player: color, pauseControl: game.pauseControl)
+                    InlineTimerView(timeControl: game.gameData?.timeControl, clock: game.clock, player: color, pauseControl: game.pauseControl, gameFinished: game.gamePhase == .finished)
                 }
             }
         } else {
@@ -76,7 +76,7 @@ struct PlayerInfoLine: View {
                                 .font(.subheadline)
                         }
                     }
-                    InlineTimerView(timeControl: game.gameData?.timeControl, clock: game.clock, player: color, pauseControl: game.pauseControl)
+                    InlineTimerView(timeControl: game.gameData?.timeControl, clock: game.clock, player: color, pauseControl: game.pauseControl, gameFinished: game.gamePhase == .finished)
                 }
                 Spacer()
             }

--- a/Surround/Components/InlineTimerView.swift
+++ b/Surround/Components/InlineTimerView.swift
@@ -95,6 +95,7 @@ struct InlineTimerView: View {
     var subFont: Font?
     var pauseControl: OGSPauseControl?
     var showsPauseReason = true
+    var gameFinished: Bool
 
     var body: some View {
         guard let clock = clock, let timeControl = timeControl else {
@@ -107,6 +108,7 @@ struct InlineTimerView: View {
 
         let playerId = player == .black ? clock.blackPlayerId : clock.whitePlayerId
         let isPaused = pauseControl?.isPaused() ?? false
+        let isFinished = self.gameFinished
         let pausedReason = pauseControl?.pauseReason(playerId: playerId) ?? ""
         
         return AnyView(HStack(alignment: .firstTextBaseline) {
@@ -142,7 +144,7 @@ struct InlineTimerView: View {
                 default:
                     Text(verbatim: "").font(mainFont)
                 }
-                if isPaused {
+                if isPaused && !isFinished {
                     if showsPauseReason {
                         Text(pausedReason).font(subFont.bold()).minimumScaleFactor(0.5)
                     } else {
@@ -175,9 +177,9 @@ struct InlineTimerView_Previews: PreviewProvider {
         )
 
         return Group {
-            InlineTimerView(timeControl: timeControl1, clock: clock1, player: .black)
-            InlineTimerView(timeControl: timeControl1, clock: clock1, player: .white)
-            InlineTimerView(timeControl: timeControl2, clock: clock2, player: .white)
+            InlineTimerView(timeControl: timeControl1, clock: clock1, player: .black, gameFinished: false)
+            InlineTimerView(timeControl: timeControl1, clock: clock1, player: .white, gameFinished: false)
+            InlineTimerView(timeControl: timeControl2, clock: clock2, player: .white, gameFinished: false)
         }.previewLayout(.fixed(width: 180, height: 44))
     }
 }

--- a/Surround/Views/GameDetail/PlayersBannerView.swift
+++ b/Surround/Views/GameDetail/PlayersBannerView.swift
@@ -344,7 +344,8 @@ struct PlayersBannerView: View {
                                 mainFont: .subheadline,
                                 subFont: .footnote,
                                 pauseControl: game.pauseControl,
-                                showsPauseReason: true)
+                                showsPauseReason: true,
+                                gameFinished: game.gamePhase == .finished)
                         }
                         ScrollView {
                             VStack(alignment: .leading, spacing: 5) {
@@ -365,7 +366,8 @@ struct PlayersBannerView: View {
                                 mainFont: .subheadline,
                                 subFont: .footnote,
                                 pauseControl: game.pauseControl,
-                                showsPauseReason: true
+                                showsPauseReason: true,
+                                gameFinished: game.gamePhase == .finished
                             )
                             Stone(color: topLeftPlayerColor.opponentColor(), shadowRadius: 2)
                                 .frame(width: 20, height: 20)

--- a/Surround/Views/GameDetail/SingleGameView.swift
+++ b/Surround/Views/GameDetail/SingleGameView.swift
@@ -199,7 +199,8 @@ struct SingleGameView: View {
                         clock: game.clock,
                         player: currentPlayerColor,
                         pauseControl: game.pauseControl,
-                        showsPauseReason: true
+                        showsPauseReason: true,
+                        gameFinished: game.gamePhase == .finished
                     )
                 }
             }


### PR DESCRIPTION
Instead of showing "Stone removal" on finished games:
<img width="391" alt="Screenshot 2024-08-28 at 12 57 19" src="https://github.com/user-attachments/assets/8e6c36cd-c277-4b4c-90ce-1b8633159725">
<img width="392" alt="Screenshot 2024-08-28 at 12 57 07" src="https://github.com/user-attachments/assets/b7af6324-5e41-4067-843a-6323e7a26d40">
